### PR TITLE
Fix AIS autocomplete on mobile and shrink suggestion font

### DIFF
--- a/src/components/AddressSearchControl.vue
+++ b/src/components/AddressSearchControl.vue
@@ -117,11 +117,12 @@ onBeforeUnmount(() => {
           <input
             :id="inputId"
             ref="inputRef"
-            v-model="MainStore.addressSearchValue"
+            :value="MainStore.addressSearchValue"
             class="input address-input"
             type="text"
             placeholder="Search an address, OPA, or DOR number"
             autocomplete="off"
+            @input="MainStore.addressSearchValue = $event.target.value"
             @keydown.enter="replaceRoute(MainStore.addressSearchValue)"
             @keydown="onInputKeydown"
           >

--- a/src/components/SearchSuggestions.vue
+++ b/src/components/SearchSuggestions.vue
@@ -120,6 +120,7 @@ defineExpose({ focusFirst });
 
 .search-suggestion {
   padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
   cursor: pointer;
   color: #000;
   outline: none;


### PR DESCRIPTION
## Summary
- Fix AIS address autocomplete on mobile: replace `v-model` with `:value` + `@input` on the search input. Mobile keyboards (Gboard, some iOS configs) keep the input in IME composition, which `v-model` ignores until composition ends — so `addressSearchValue` never updated and no suggestions appeared until the keyboard was dismissed. The raw `@input` handler fires on every keystroke regardless of composition state.
- Make the suggestion dropdown font size explicit (`0.875rem`) so it no longer inherits the app's ambient `body` font.

## Test plan
- [ ] On a phone, type an address in the search box — suggestions appear as you type, without dismissing the keyboard.
- [ ] Desktop autocomplete still works (type 3+ chars, click or keyboard-select a suggestion).
- [ ] Suggestion text renders at the smaller size.